### PR TITLE
Исправлена ошибка применения темы у DevExpress

### DIFF
--- a/samples/XpfDemoApp/MainWindow.xaml
+++ b/samples/XpfDemoApp/MainWindow.xaml
@@ -111,8 +111,8 @@
 
             <dxe:ComboBoxEdit
                 x:Name="_themesComboBox"
-                SelectedIndex="0"
-                ValueMember="Value"
+                SelectedIndex="1"
+                ValueMember="Id"
                 DisplayMember="DisplayName"
                 IsTextEditable="False"
                 ItemsSource="{me:EnumToItemsSource ss:UIThemes}"

--- a/src/dosymep.Xpf.Core.Ninject/NinjectExtensions.cs
+++ b/src/dosymep.Xpf.Core.Ninject/NinjectExtensions.cs
@@ -61,6 +61,7 @@ public static class NinjectExtensions {
     /// <param name="kernel">Ninject контейнер.</param>
     /// <returns>Возвращает настроенный контейнер Ninject.</returns>
     /// <exception cref="ArgumentNullException">kernel is null.</exception>
+    [Obsolete("Сервис применения темы теперь применяется автоматически")]
     public static IKernel UseXtraThemeUpdater(this IKernel kernel) {
         if(kernel == null) {
             throw new ArgumentNullException(nameof(kernel));
@@ -89,7 +90,7 @@ public static class NinjectExtensions {
 
         return kernel;
     }
-    
+
     /// <summary>
     /// Добавляет в контейнер <see cref="IDispatcherService"/>.
     /// </summary>
@@ -127,7 +128,7 @@ public static class NinjectExtensions {
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeService),
                 c => c.Kernel.Get<IUIThemeService>())
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeUpdaterService),
-                c => c.Kernel.Get<IUIThemeUpdaterService>())
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), false);
 
         return kernel;
@@ -152,7 +153,7 @@ public static class NinjectExtensions {
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeService),
                 c => c.Kernel.Get<IUIThemeService>())
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeUpdaterService),
-                c => c.Kernel.Get<IUIThemeUpdaterService>())
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), true);
 
         return kernel;
@@ -182,7 +183,7 @@ public static class NinjectExtensions {
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeService),
                 c => c.Kernel.Get<IUIThemeService>())
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeUpdaterService),
-                c => c.Kernel.Get<IUIThemeUpdaterService>())
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), false)
             .WithPropertyValue(nameof(XtraProgressDialogService.DisplayTitleFormat), displayTitleFormat)
             .WithPropertyValue(nameof(XtraProgressDialogService.StepValue), stepValue)
@@ -218,7 +219,7 @@ public static class NinjectExtensions {
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeService),
                 c => c.Kernel.Get<IUIThemeService>())
             .WithPropertyValue(nameof(XtraProgressDialogService.UIThemeUpdaterService),
-                c => c.Kernel.Get<IUIThemeUpdaterService>())
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(XtraProgressDialogService.DisplayTitleFormat), displayTitleFormat)
             .WithPropertyValue(nameof(XtraProgressDialogService.StepValue), stepValue)
             .WithPropertyValue(nameof(XtraProgressDialogService.Indeterminate), indeterminate);
@@ -324,6 +325,28 @@ public static class NinjectExtensions {
 
         return kernel;
     }
+    
+    /// <summary>
+    /// Добавляет в контейнер <see cref="ILocalizationService"/>.
+    /// </summary>
+    /// <param name="kernel">Ninject контейнер.</param>
+    /// <param name="resourceName">Наименование ресурсов.</param>
+    /// <param name="defaultCulture">Языковые настройки по умолчанию. Значение по умолчанию <see cref="CultureInfo.CurrentUICulture"/>.</param>
+    /// <returns>Возвращает настроенный контейнер Ninject.</returns>
+    public static IKernel UseXtraLocalization(this IKernel kernel, string resourceName,
+        CultureInfo? defaultCulture = default) {
+        kernel.Bind<ILocalizationService>().To<XtraLocalizationService>()
+            .InSingletonScope()
+            .WithConstructorArgument(nameof(resourceName), resourceName)
+            .WithConstructorArgument(nameof(defaultCulture), defaultCulture ?? CultureInfo.CurrentUICulture)
+            .OnActivation((context, service) =>
+                service.SetLocalization(
+                    context.Kernel.TryGet<ILanguageService>()?.HostLanguage
+                    ?? defaultCulture
+                    ?? CultureInfo.CurrentUICulture));
+
+        return kernel;
+    }
 
     /// <summary>
     /// Добавляет в контейнер <see cref="IOpenFileDialogService"/>.
@@ -366,6 +389,10 @@ public static class NinjectExtensions {
 
         kernel.Bind<IOpenFileDialogService>()
             .To<XtraOpenFileDialogService>()
+            .WithPropertyValue(nameof(XtraOpenFileDialogService.UIThemeService),
+                c => c.Kernel.Get<IUIThemeService>())
+            .WithPropertyValue(nameof(XtraOpenFileDialogService.UIThemeUpdaterService),
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), false)
             .WithPropertyValue(nameof(IOpenDialogServiceBase.Multiselect), multiSelect)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AddExtension), addExtension)
@@ -430,6 +457,10 @@ public static class NinjectExtensions {
         kernel.Bind<IOpenFileDialogService>()
             .To<XtraOpenFileDialogService>()
             .WhenInjectedInto<T>()
+            .WithPropertyValue(nameof(XtraOpenFileDialogService.UIThemeService),
+                c => c.Kernel.Get<IUIThemeService>())
+            .WithPropertyValue(nameof(XtraOpenFileDialogService.UIThemeUpdaterService),
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), true)
             .WithPropertyValue(nameof(IOpenDialogServiceBase.Multiselect), multiSelect)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AddExtension), addExtension)
@@ -493,6 +524,10 @@ public static class NinjectExtensions {
 
         kernel.Bind<ISaveFileDialogService>()
             .To<XtraSaveFileDialogService>()
+            .WithPropertyValue(nameof(XtraSaveFileDialogService.UIThemeService),
+                c => c.Kernel.Get<IUIThemeService>())
+            .WithPropertyValue(nameof(XtraSaveFileDialogService.UIThemeUpdaterService),
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), false)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AddExtension), addExtension)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AutoUpgradeEnabled), autoUpgradeEnabled)
@@ -511,27 +546,6 @@ public static class NinjectExtensions {
             .WithPropertyValue(nameof(ISaveFileDialogService.DefaultExt), defaultExt!)
             .WithPropertyValue(nameof(ISaveFileDialogService.DefaultFileName), defaultFileName!);
 
-        return kernel;
-    }
-
-    /// <summary>
-    /// Добавляет в контейнер <see cref="ILocalizationService"/>.
-    /// </summary>
-    /// <param name="kernel">Ninject контейнер.</param>
-    /// <param name="resourceName">Наименование ресурсов.</param>
-    /// <param name="defaultCulture">Языковые настройки по умолчанию. Значение по умолчанию <see cref="CultureInfo.CurrentUICulture"/>.</param>
-    /// <returns>Возвращает настроенный контейнер Ninject.</returns>
-    public static IKernel UseXtraLocalization(this IKernel kernel, string resourceName, CultureInfo? defaultCulture = default) {
-        kernel.Bind<ILocalizationService>().To<XtraLocalizationService>()
-            .InSingletonScope()
-            .WithConstructorArgument(nameof(resourceName), resourceName)
-            .WithConstructorArgument(nameof(defaultCulture), defaultCulture ?? CultureInfo.CurrentUICulture)
-            .OnActivation((context, service) =>
-                service.SetLocalization(
-                    context.Kernel.TryGet<ILanguageService>()?.HostLanguage
-                    ?? defaultCulture
-                    ?? CultureInfo.CurrentUICulture));
-        
         return kernel;
     }
 
@@ -581,6 +595,10 @@ public static class NinjectExtensions {
         kernel.Bind<ISaveFileDialogService>()
             .To<XtraSaveFileDialogService>()
             .WhenInjectedInto<T>()
+            .WithPropertyValue(nameof(XtraSaveFileDialogService.UIThemeService),
+                c => c.Kernel.Get<IUIThemeService>())
+            .WithPropertyValue(nameof(XtraSaveFileDialogService.UIThemeUpdaterService),
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), true)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AddExtension), addExtension)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AutoUpgradeEnabled), autoUpgradeEnabled)
@@ -631,6 +649,10 @@ public static class NinjectExtensions {
 
         kernel.Bind<IOpenFolderDialogService>()
             .To<XtraOpenFolderDialogService>()
+            .WithPropertyValue(nameof(XtraOpenFolderDialogService.UIThemeService),
+                c => c.Kernel.Get<IUIThemeService>())
+            .WithPropertyValue(nameof(XtraOpenFolderDialogService.UIThemeUpdaterService),
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), false)
             .WithPropertyValue(nameof(IOpenDialogServiceBase.Multiselect), multiSelect)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AutoUpgradeEnabled), autoUpgradeEnabled)
@@ -676,6 +698,10 @@ public static class NinjectExtensions {
         kernel.Bind<IOpenFolderDialogService>()
             .To<XtraOpenFolderDialogService>()
             .WhenInjectedInto<T>()
+            .WithPropertyValue(nameof(XtraOpenFolderDialogService.UIThemeService),
+                c => c.Kernel.Get<IUIThemeService>())
+            .WithPropertyValue(nameof(XtraOpenFolderDialogService.UIThemeUpdaterService),
+                c => new XtraThemeUpdaterService())
             .WithPropertyValue(nameof(IAttachableService.AllowAttach), true)
             .WithPropertyValue(nameof(IOpenDialogServiceBase.Multiselect), multiSelect)
             .WithPropertyValue(nameof(IFileDialogServiceBase.AutoUpgradeEnabled), autoUpgradeEnabled)

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/CustomDXOpenFileDialogService.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/CustomDXOpenFileDialogService.cs
@@ -1,0 +1,29 @@
+using DevExpress.Utils.CommonDialogs;
+using DevExpress.Xpf.Dialogs;
+
+using dosymep.SimpleServices;
+using dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs;
+
+namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices {
+    /// <summary>
+    /// Internal use only.
+    /// </summary>
+    public class CustomDXOpenFileDialogService : DXOpenFileDialogService {
+        /// <summary>
+        /// Сервис по получению тем.
+        /// </summary>
+        public IUIThemeService UIThemeService { get; set; }
+
+        /// <summary>
+        /// Сервис по установке тем.
+        /// </summary>
+        public IUIThemeUpdaterService UIThemeUpdaterService { get; set; }
+
+
+        /// <summary>
+        /// Internal use only.
+        /// </summary>
+        protected override IFileDialog CreateFileDialogAdapter() =>
+            new CustomDXOpenFileDialog(() => UIThemeService, () => UIThemeUpdaterService);
+    }
+}

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/CustomDXOpenFolderDialogService.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/CustomDXOpenFolderDialogService.cs
@@ -1,0 +1,28 @@
+using DevExpress.Utils.CommonDialogs;
+using DevExpress.Xpf.Dialogs;
+
+using dosymep.SimpleServices;
+using dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs;
+
+namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices {
+    /// <summary>
+    /// Internal use only.
+    /// </summary>
+    public class CustomDXOpenFolderDialogService : DXOpenFolderDialogService {
+        /// <summary>
+        /// Сервис по получению тем.
+        /// </summary>
+        public IUIThemeService UIThemeService { get; set; }
+
+        /// <summary>
+        /// Сервис по установке тем.
+        /// </summary>
+        public IUIThemeUpdaterService UIThemeUpdaterService { get; set; }
+
+        /// <summary>
+        /// Internal use only.
+        /// </summary>
+        protected override IFileDialog CreateFileDialogAdapter() =>
+            new CustomDXOpenFileDialog(() => UIThemeService, () => UIThemeUpdaterService);
+    }
+}

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/CustomDXSaveFileDialogService.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/CustomDXSaveFileDialogService.cs
@@ -1,0 +1,28 @@
+using DevExpress.Utils.CommonDialogs;
+using DevExpress.Xpf.Dialogs;
+
+using dosymep.SimpleServices;
+using dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs;
+
+namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices {
+    /// <summary>
+    /// Internal use only.
+    /// </summary>
+    public class CustomDXSaveFileDialogService : DXSaveFileDialogService {
+        /// <summary>
+        /// Сервис по получению тем.
+        /// </summary>
+        public IUIThemeService UIThemeService { get; set; }
+
+        /// <summary>
+        /// Сервис по установке тем.
+        /// </summary>
+        public IUIThemeUpdaterService UIThemeUpdaterService { get; set; }
+
+        /// <summary>
+        /// Internal use only.
+        /// </summary>
+        protected override IFileDialog CreateFileDialogAdapter() =>
+            new CustomDXSaveFileDialog(() => UIThemeService, () => UIThemeUpdaterService);
+    }
+}

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXOpenFileDialog.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXOpenFileDialog.cs
@@ -24,7 +24,14 @@ namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs {
                 ShowInTaskbar = false
             };
             
-            _themeUpdaterService().SetTheme(_theme().HostTheme, fileDialogWindow);
+            IUIThemeService themeService = _theme();
+            IUIThemeUpdaterService themeUpdaterService = _themeUpdaterService();
+
+            if(themeService is null || themeUpdaterService is null) {
+                ThemeManager.SetTheme(fileDialogWindow, Theme.Win10Light);
+            } else {
+                themeUpdaterService.SetTheme(themeService.HostTheme, fileDialogWindow);
+            }
 
             return fileDialogWindow;
         }

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXOpenFileDialog.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXOpenFileDialog.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Windows;
+
+using DevExpress.Xpf.Core;
+using DevExpress.Xpf.Dialogs;
+
+using dosymep.SimpleServices;
+
+namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs {
+    internal class CustomDXOpenFileDialog : DXOpenFileDialog {
+        private readonly Func<IUIThemeService> _theme;
+        private readonly Func<IUIThemeUpdaterService> _themeUpdaterService;
+
+        public CustomDXOpenFileDialog(Func<IUIThemeService> theme, Func<IUIThemeUpdaterService> themeUpdaterService) {
+            _theme = theme;
+            _themeUpdaterService = themeUpdaterService;
+        }
+
+        protected override IDialogHost CreateDialogHost(IntPtr hwndOwner) {
+            FileDialogWindow fileDialogWindow = new FileDialogWindow {
+                Title = string.IsNullOrEmpty(Title) ? GetDefaultTitle() : Title,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                WindowStyle = WindowStyle.ToolWindow,
+                ShowInTaskbar = false
+            };
+            
+            _themeUpdaterService().SetTheme(_theme().HostTheme, fileDialogWindow);
+
+            return fileDialogWindow;
+        }
+    }
+}

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXSaveFileDialog.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXSaveFileDialog.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Windows;
+
+using DevExpress.Xpf.Core;
+using DevExpress.Xpf.Dialogs;
+
+using dosymep.SimpleServices;
+
+namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs {
+    internal class CustomDXSaveFileDialog : DXSaveFileDialog {
+        private readonly Func<IUIThemeService> _theme;
+        private readonly Func<IUIThemeUpdaterService> _themeUpdaterService;
+
+        public CustomDXSaveFileDialog(Func<IUIThemeService> theme, Func<IUIThemeUpdaterService> themeUpdaterService) {
+            _theme = theme;
+            _themeUpdaterService = themeUpdaterService;
+        }
+
+        protected override IDialogHost CreateDialogHost(IntPtr hwndOwner) {
+            FileDialogWindow fileDialogWindow = new FileDialogWindow {
+                Title = string.IsNullOrEmpty(Title) ? GetDefaultTitle() : Title,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                WindowStyle = WindowStyle.ToolWindow,
+                ShowInTaskbar = false
+            };
+
+            _themeUpdaterService().SetTheme(_theme().HostTheme, fileDialogWindow);
+
+            return fileDialogWindow;
+        }
+    }
+}

--- a/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXSaveFileDialog.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/DxCustomServices/DXCustomDialogs/CustomDXSaveFileDialog.cs
@@ -23,9 +23,16 @@ namespace dosymep.Xpf.Core.SimpleServices.DxCustomServices.DXCustomDialogs {
                 WindowStyle = WindowStyle.ToolWindow,
                 ShowInTaskbar = false
             };
+           
+            IUIThemeService themeService = _theme();
+            IUIThemeUpdaterService themeUpdaterService = _themeUpdaterService();
 
-            _themeUpdaterService().SetTheme(_theme().HostTheme, fileDialogWindow);
-
+            if(themeService is null || themeUpdaterService is null) {
+                ThemeManager.SetTheme(fileDialogWindow, Theme.Win10Light);
+            } else {
+                themeUpdaterService.SetTheme(themeService.HostTheme, fileDialogWindow);
+            }
+            
             return fileDialogWindow;
         }
     }

--- a/src/dosymep.Xpf.Core/SimpleServices/XtraOpenFileDialogService.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/XtraOpenFileDialogService.cs
@@ -1,23 +1,41 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
 
 using DevExpress.Mvvm.UI;
-using DevExpress.Xpf.Dialogs;
+using DevExpress.Xpf.Core;
 
 using dosymep.SimpleServices;
+using dosymep.Xpf.Core.SimpleServices.DxCustomServices;
 
 namespace dosymep.Xpf.Core.SimpleServices {
     /// <summary>
     /// Класс сервиса открытия диалога выбора файла.
     /// </summary>
-    public class XtraOpenFileDialogService :  XtraBaseWindowService<DXOpenFileDialogService>, IOpenFileDialogService {
+    public class XtraOpenFileDialogService :  XtraBaseWindowService<CustomDXOpenFileDialogService>, IOpenFileDialogService {
+        /// <summary>
+        /// Сервис по получению тем.
+        /// </summary>
+        public IUIThemeService UIThemeService {
+            get => _serviceBase.UIThemeService;
+            set => _serviceBase.UIThemeService = value;
+        }
+
+        /// <summary>
+        /// Сервис по установке тем.
+        /// </summary>
+        public IUIThemeUpdaterService UIThemeUpdaterService {
+            get => _serviceBase.UIThemeUpdaterService;
+            set => _serviceBase.UIThemeUpdaterService = value;
+        }
+        
         /// <summary>
         /// Создает экземпляр сервиса открытия диалога выбора файла.
         /// </summary>
         public XtraOpenFileDialogService()
-            : base(new DXOpenFileDialogService()) {
+            : base(new CustomDXOpenFileDialogService()) {
         }
 
         /// <inheritdoc />

--- a/src/dosymep.Xpf.Core/SimpleServices/XtraOpenFolderDialogService.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/XtraOpenFolderDialogService.cs
@@ -1,25 +1,40 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Windows;
 
 using DevExpress.Xpf.Dialogs;
 
 using dosymep.SimpleServices;
+using dosymep.Xpf.Core.SimpleServices.DxCustomServices;
 
 namespace dosymep.Xpf.Core.SimpleServices {
     /// <summary>
     /// Класс сервиса открытия диалога выбора папки.
     /// </summary>
-    public class XtraOpenFolderDialogService : 
-        XtraBaseWindowService<DXOpenFolderDialogService>,
+    public class XtraOpenFolderDialogService :
+        XtraBaseWindowService<CustomDXOpenFolderDialogService>,
         IOpenFolderDialogService {
-        
+        /// <summary>
+        /// Сервис по получению тем.
+        /// </summary>
+        public IUIThemeService UIThemeService {
+            get => _serviceBase.UIThemeService;
+            set => _serviceBase.UIThemeService = value;
+        }
+
+        /// <summary>
+        /// Сервис по установке тем.
+        /// </summary>
+        public IUIThemeUpdaterService UIThemeUpdaterService {
+            get => _serviceBase.UIThemeUpdaterService;
+            set => _serviceBase.UIThemeUpdaterService = value;
+        }
+
         /// <summary>
         /// Создает экземпляр сервиса открытия диалога выбора папки.
         /// </summary>
         public XtraOpenFolderDialogService()
-            : base(new DXOpenFolderDialogService()) {
+            : base(new CustomDXOpenFolderDialogService()) {
         }
 
         /// <inheritdoc />
@@ -110,7 +125,7 @@ namespace dosymep.Xpf.Core.SimpleServices {
         public void Reset() {
             ((DevExpress.Mvvm.IOpenFolderDialogService) _serviceBase).Reset();
         }
-        
+
         /// <inheritdoc />
         public bool ShowDialog() {
             return ShowDialog(null);
@@ -126,6 +141,8 @@ namespace dosymep.Xpf.Core.SimpleServices {
             => ((DirectoryInfoWrapper) ((DevExpress.Mvvm.IOpenFolderDialogService) _serviceBase).Folder).DirectoryInfo;
 
         /// <inheritdoc />
-        public IEnumerable<DirectoryInfo> Folders => ((DevExpress.Mvvm.IOpenFolderDialogService) _serviceBase).Folders.Select(item => ((DirectoryInfoWrapper) item).DirectoryInfo);
+        public IEnumerable<DirectoryInfo> Folders =>
+            ((DevExpress.Mvvm.IOpenFolderDialogService) _serviceBase).Folders.Select(item =>
+                ((DirectoryInfoWrapper) item).DirectoryInfo);
     }
 }

--- a/src/dosymep.Xpf.Core/SimpleServices/XtraSaveFileDialogService.cs
+++ b/src/dosymep.Xpf.Core/SimpleServices/XtraSaveFileDialogService.cs
@@ -1,22 +1,37 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Windows;
 
 using DevExpress.Mvvm.UI;
-using DevExpress.Xpf.Dialogs;
 
 using dosymep.SimpleServices;
+using dosymep.Xpf.Core.SimpleServices.DxCustomServices;
 
 namespace dosymep.Xpf.Core.SimpleServices {
     /// <summary>
     /// Класс сервиса открытия диалога сохранения файла.
     /// </summary>
-    public class XtraSaveFileDialogService : XtraBaseWindowService<DXSaveFileDialogService>, ISaveFileDialogService {
+    public class XtraSaveFileDialogService : XtraBaseWindowService<CustomDXSaveFileDialogService>, ISaveFileDialogService {
+        /// <summary>
+        /// Сервис по получению тем.
+        /// </summary>
+        public IUIThemeService UIThemeService {
+            get => _serviceBase.UIThemeService;
+            set => _serviceBase.UIThemeService = value;
+        }
+
+        /// <summary>
+        /// Сервис по установке тем.
+        /// </summary>
+        public IUIThemeUpdaterService UIThemeUpdaterService {
+            get => _serviceBase.UIThemeUpdaterService;
+            set => _serviceBase.UIThemeUpdaterService = value;
+        }
+        
         /// <summary>
         /// Создает экземпляр сервиса открытия диалога сохранения файла.
         /// </summary>
         public XtraSaveFileDialogService()
-            : base(new DXSaveFileDialogService()) {
+            : base(new CustomDXSaveFileDialogService()) {
         }
 
         /// <inheritdoc />
@@ -123,3 +138,4 @@ namespace dosymep.Xpf.Core.SimpleServices {
         public FileInfo File => ((FileInfoWrapper) ((DevExpress.Mvvm.ISaveFileDialogService)_serviceBase).File).FileInfo;
     }
 }
+


### PR DESCRIPTION
Исправлена ошибка применения темы у DevExpress, когда родительское окно не являлось DevExpress окном.
Известные проблемы - пока не работает для MessageBoxService. Так как он в общем уже был давно портирован на WPF-UI, то думаю особо с ним проблем не будет.